### PR TITLE
fixing master branch build failure & nested example BigQuery job failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ cp run-nested.example run-nested
 5. Run either script as desired.
 6. As an alternative to editing the script you can simply copy and paste the command therein to your shell replacing the aforementioned values with those specific to your project.
 
+
+    
 ## Contact Us
 
 We welcome all usage-related questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/google-cloud-dataflow)

--- a/run-nested.example
+++ b/run-nested.example
@@ -8,6 +8,6 @@ mvn compile exec:java \
     --numWorkers=20 \
     --maxNumWorkers=70 \
     --bigQueryTablename=#PROJECT_NAME:#DATASET.#DESTINATION_TABLE \
-    --diskSizeGb=1000 \
+    --diskSizeGb=100 \
     --workerMachineType=n1-standard-1"
 

--- a/run-simple.example
+++ b/run-simple.example
@@ -8,6 +8,6 @@ mvn compile exec:java \
     --numWorkers=20 \
     --maxNumWorkers=72 \
     --bigQueryTablename=#PROJECT:#DATASET.#DESTINATION_TABLE\
-    --diskSizeGb=1000 \
+    --diskSizeGb=100 \
     --workerMachineType=n1-standard-1"
 

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -61,7 +61,7 @@ public class BQETLNested {
 
     // fixing incorrect column name changing artist_credit_name_artist to artist_credit_name
     //PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name_artist", recordingCredits), "recordings");
-    PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name", recordingCredits), "recordings");
+    PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name_artist", recordingCredits), "recordings");
 
 
         /*

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -43,16 +43,13 @@ public class BQETLNested {
 
     // load the line delimited JSON into keyed PCollections
     PCollection<KV<Long, MusicBrainzDataObject>> artists = MusicBrainzTransforms.loadTable(p, "artist", "id",
-        MusicBrainzTransforms.lookup("area", "id", "name", "area"),
-        //MusicBrainzTransforms.lookup("area", "id", "name", "area", "begin_area"),
-        MusicBrainzTransforms.lookup("gender", "id", "name", "gender"));
-        //MusicBrainzTransforms.lookup("gender", "gender", "id", "name"));
+        MusicBrainzTransforms.lookup("area", "id", "name", "area"),  // removed begin_area from list of destinationKeys to replace
+        MusicBrainzTransforms.lookup("gender", "id", "name", "gender"));  // moved second gender to the end as a destinationKey to replace
     PCollection<KV<Long, MusicBrainzDataObject>> artistCreditName = MusicBrainzTransforms.loadTable(p, "artist_credit_name", "artist_credit");
     PCollection<KV<Long, MusicBrainzDataObject>> recordingsByArtistCredit = MusicBrainzTransforms.loadTable(p, "recording", "artist_credit");
 
-    // changing innerJoin result name from nested recordings to recordings
+    // changed innerJoin result name from nested recordings to recordings
     PCollection<MusicBrainzDataObject> recordingCredits = MusicBrainzTransforms.innerJoin("recordings", artistCreditName, recordingsByArtistCredit);
-    //PCollection<MusicBrainzDataObject> recordingCredits = MusicBrainzTransforms.innerJoin("nested recordings", artistCreditName, recordingsByArtistCredit);
     PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name_artist", recordingCredits), "recordings");
 
     // create the table schema for Big Query
@@ -73,42 +70,6 @@ public class BQETLNested {
     p.run();
   }
 
-//  return FieldSchemaListBuilder.create()
-//      .intField("artist_id")
-//  .stringField("artist_gid")
-//  .stringField("artist_name")
-//  .stringField("artist_sort_name")
-//  .intField("artist_begin_date_year")
-//  .intField("artist_begin_date_month")
-//  .intField("artist_begin_date_day")
-//  .intField("artist_end_date_year")
-//  .intField("artist_end_date_month")
-//  .intField("artist_end_date_day")
-//  .boolField("artist_ended")
-//  .intField("artist_type")
-//  .stringField("artist_gender")
-//  .stringField("artist_area")
-//  .intField("artist_begin_area")
-//  .intField("artist_end_area")
-//  .stringField("artist_comment")
-//  .intField("artist_edits_pending")
-//  .timestampField("artist_last_updated")
-//  .field(FieldSchemaListBuilder.create()
-//  .intField("artist_credit_name_artist_credit")
-//  .intField("artist_credit_name_position")
-//  .intField("artist_credit_name_artist")
-//  .stringField("artist_credit_name_name")
-//  .stringField("artist_credit_name_join_phrase")
-//  .intField("recording_id")
-//  .stringField("recording_gid")
-//  .stringField("recording_name")
-//  .intField("recording_length")
-//  .stringField("recording_comment")
-//  .intField("recording_edits_pending")
-//  .timestampField("recording_last_updated")
-//  //.boolField("recording_video")
-//  .repeatedRecord("artist_recordings")).schema();
-
   private static TableSchema bqSchema() {
     return FieldSchemaListBuilder.create()
         .intField("artist_id")
@@ -122,25 +83,17 @@ public class BQETLNested {
         .intField("artist_end_date_month")
         .intField("artist_end_date_day")
         .intField("artist_type")
-        // [START schemaCodeChange]
-/*Switch these two lines when using mapping table for artist_area */
+        /*Switch these two lines when using mapping table for artist_area */
         .stringField("artist_area")
-//        .intField("artist_area")
-        // [END schemaCodeChange]
-        // [START schemaCodeChange2]
-/*Switch these two lines when using mapping table for artist_gender */
+        //.intField("artist_area")
+        /*Switch these two lines when using mapping table for artist_gender */
         .stringField("artist_gender")
-//        .intField("artist_gender")
-        //[END schemaCodeChange2]
+        //.intField("artist_gender")
         .intField("artist_edits_pending")
         .timestampField("artist_last_updated")
         .stringField("artist_comment")
         .boolField("artist_ended")
-/*Switch these two lines when using mapping table for artist_begin_area */
-        // [START schemaCodeChange3]
         .intField("artist_begin_area")
-        //      .stringField("artist_begin_area")
-        // [END schemaCodeChange3]
         .field(FieldSchemaListBuilder.create()
             .intField("artist_credit_name_artist_credit")
             .intField("artist_credit_name_position")

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -43,7 +43,8 @@ public class BQETLNested {
 
     // load the line delimited JSON into keyed PCollections
     PCollection<KV<Long, MusicBrainzDataObject>> artists = MusicBrainzTransforms.loadTable(p, "artist", "id",
-        MusicBrainzTransforms.lookup("area", "id", "name", "area", "begin_area"),
+        MusicBrainzTransforms.lookup("area", "id", "name", "area"),
+        //MusicBrainzTransforms.lookup("area", "id", "name", "area", "begin_area"),
         MusicBrainzTransforms.lookup("gender", "id", "name", "gender"));
         //MusicBrainzTransforms.lookup("gender", "gender", "id", "name"));
     PCollection<KV<Long, MusicBrainzDataObject>> artistCreditName = MusicBrainzTransforms.loadTable(p, "artist_credit_name", "artist_credit");

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -72,6 +72,42 @@ public class BQETLNested {
     p.run();
   }
 
+//  return FieldSchemaListBuilder.create()
+//      .intField("artist_id")
+//  .stringField("artist_gid")
+//  .stringField("artist_name")
+//  .stringField("artist_sort_name")
+//  .intField("artist_begin_date_year")
+//  .intField("artist_begin_date_month")
+//  .intField("artist_begin_date_day")
+//  .intField("artist_end_date_year")
+//  .intField("artist_end_date_month")
+//  .intField("artist_end_date_day")
+//  .boolField("artist_ended")
+//  .intField("artist_type")
+//  .stringField("artist_gender")
+//  .stringField("artist_area")
+//  .intField("artist_begin_area")
+//  .intField("artist_end_area")
+//  .stringField("artist_comment")
+//  .intField("artist_edits_pending")
+//  .timestampField("artist_last_updated")
+//  .field(FieldSchemaListBuilder.create()
+//  .intField("artist_credit_name_artist_credit")
+//  .intField("artist_credit_name_position")
+//  .intField("artist_credit_name_artist")
+//  .stringField("artist_credit_name_name")
+//  .stringField("artist_credit_name_join_phrase")
+//  .intField("recording_id")
+//  .stringField("recording_gid")
+//  .stringField("recording_name")
+//  .intField("recording_length")
+//  .stringField("recording_comment")
+//  .intField("recording_edits_pending")
+//  .timestampField("recording_last_updated")
+//  //.boolField("recording_video")
+//  .repeatedRecord("artist_recordings")).schema();
+
   private static TableSchema bqSchema() {
     return FieldSchemaListBuilder.create()
         .intField("artist_id")
@@ -84,15 +120,26 @@ public class BQETLNested {
         .intField("artist_end_date_year")
         .intField("artist_end_date_month")
         .intField("artist_end_date_day")
-        .boolField("artist_ended")
         .intField("artist_type")
-        .stringField("artist_gender")
-        .stringField("artist_area")
-        .intField("artist_begin_area")
-        .intField("artist_end_area")
-        .stringField("artist_comment")
+        // [START schemaCodeChange]
+/*Switch these two lines when using mapping table for artist_area */
+        //        .stringField("artist_area")
+        .intField("artist_area")
+        // [END schemaCodeChange]
+        // [START schemaCodeChange2]
+/*Switch these two lines when using mapping table for artist_gender */
+        //        .stringField("artist_gender")
+        .intField("artist_gender")
+        //[END schemaCodeChange2]
         .intField("artist_edits_pending")
         .timestampField("artist_last_updated")
+        .stringField("artist_comment")
+        .boolField("artist_ended")
+/*Switch these two lines when using mapping table for artist_begin_area */
+        // [START schemaCodeChange3]
+        .intField("artist_begin_area")
+        //      .stringField("artist_begin_area")
+        // [END schemaCodeChange3]
         .field(FieldSchemaListBuilder.create()
             .intField("artist_credit_name_artist_credit")
             .intField("artist_credit_name_position")
@@ -102,11 +149,12 @@ public class BQETLNested {
             .intField("recording_id")
             .stringField("recording_gid")
             .stringField("recording_name")
+            .intField("recording_artist_credit")
             .intField("recording_length")
             .stringField("recording_comment")
             .intField("recording_edits_pending")
             .timestampField("recording_last_updated")
-            //.boolField("recording_video")
+            .boolField("recording_video")
             .repeatedRecord("artist_recordings")).schema();
   }
 }

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -55,9 +55,13 @@ public class BQETLNested {
     PCollection<KV<Long, MusicBrainzDataObject>> artistCreditName = MusicBrainzTransforms.loadTable(p, "artist_credit_name", "artist_credit");
     PCollection<KV<Long, MusicBrainzDataObject>> recordingsByArtistCredit = MusicBrainzTransforms.loadTable(p, "recording", "artist_credit");
 
-    PCollection<MusicBrainzDataObject> recordingCredits = MusicBrainzTransforms.innerJoin("nested recordings", artistCreditName, recordingsByArtistCredit);
+    // changing innerJoin result name from nested recordings to recordings
+    PCollection<MusicBrainzDataObject> recordingCredits = MusicBrainzTransforms.innerJoin("recordings", artistCreditName, recordingsByArtistCredit);
+    //PCollection<MusicBrainzDataObject> recordingCredits = MusicBrainzTransforms.innerJoin("nested recordings", artistCreditName, recordingsByArtistCredit);
 
-    PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name_artist", recordingCredits), "recordings");
+    // fixing incorrect column name changing artist_credit_name_artist to artist_credit_name
+    //PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name_artist", recordingCredits), "recordings");
+    PCollection<MusicBrainzDataObject> artistsWithRecordings = MusicBrainzTransforms.nest(artists, MusicBrainzTransforms.by("artist_credit_name", recordingCredits), "recordings");
 
 
         /*

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -128,8 +128,8 @@ public class BQETLNested {
         // [END schemaCodeChange]
         // [START schemaCodeChange2]
 /*Switch these two lines when using mapping table for artist_gender */
-        //        .stringField("artist_gender")
-        .intField("artist_gender")
+        .stringField("artist_gender")
+//        .intField("artist_gender")
         //[END schemaCodeChange2]
         .intField("artist_edits_pending")
         .timestampField("artist_last_updated")

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -123,8 +123,8 @@ public class BQETLNested {
         .intField("artist_type")
         // [START schemaCodeChange]
 /*Switch these two lines when using mapping table for artist_area */
-        //        .stringField("artist_area")
-        .intField("artist_area")
+        .stringField("artist_area")
+//        .intField("artist_area")
         // [END schemaCodeChange]
         // [START schemaCodeChange2]
 /*Switch these two lines when using mapping table for artist_gender */

--- a/src/main/java/com/google/cloud/bqetl/BQETLNested.java
+++ b/src/main/java/com/google/cloud/bqetl/BQETLNested.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.bqetl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bqetl.mbdata.MusicBrainzDataObject;
@@ -27,10 +30,6 @@ import com.google.cloud.dataflow.sdk.io.BigQueryIO;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static com.google.cloud.bqetl.mbdata.MusicBrainzTransforms.loadTable;
 
 public class BQETLNested {
   private static final Logger logger = LoggerFactory.getLogger(BQETLNested.class);
@@ -51,7 +50,8 @@ public class BQETLNested {
 
     PCollection<KV<Long, MusicBrainzDataObject>> artists = MusicBrainzTransforms.loadTable(p, "artist", "id",
         MusicBrainzTransforms.lookup("area", "id", "name", "area", "begin_area"),
-        MusicBrainzTransforms.lookup("gender", "gender", "id", "name"));
+        MusicBrainzTransforms.lookup("gender", "id", "name"));
+        //MusicBrainzTransforms.lookup("gender", "gender", "id", "name"));
     PCollection<KV<Long, MusicBrainzDataObject>> artistCreditName = MusicBrainzTransforms.loadTable(p, "artist_credit_name", "artist_credit");
     PCollection<KV<Long, MusicBrainzDataObject>> recordingsByArtistCredit = MusicBrainzTransforms.loadTable(p, "recording", "artist_credit");
 

--- a/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
+++ b/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
@@ -383,10 +383,10 @@ public class MusicBrainzTransforms {
 
     PCollection<KV<Long, String>> entries = text.apply(MapElements.via((String input) -> {
       MusicBrainzDataObject object = JSONReader.readObject("", input);
-      logger.info("keyKeyName = ", keyKeyName);
-      logger.info("valueKeyName = ", valueKeyName);
-      logger.info("(Long) object.getColumnValue(keyKeyName) = ", (Long) object.getColumnValue(keyKeyName));
-      logger.info("(String) object.getColumnValue(valueKeyName) = ", (String) object.getColumnValue(valueKeyName));
+      logger.info(String.format("keyKeyName = %s", keyKeyName), keyKeyName);
+      logger.info(String.format("valueKeyName = %s", valueKeyName), valueKeyName);
+      logger.info(String.format("(Long) object.getColumnValue(keyKeyName) = %d", (Long) object.getColumnValue(keyKeyName)), 1);
+      logger.info(String.format("(String) object.getColumnValue(valueKeyName) = %s", (String) object.getColumnValue(valueKeyName)), 2);
 //      Long key = (Long) object.getColumnValue(keyKeyName);
 //      String value = (String) object.getColumnValue(valueKeyName);
       return KV.of((Long) object.getColumnValue(keyKeyName), (String) object.getColumnValue(valueKeyName));

--- a/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
+++ b/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
@@ -382,16 +382,16 @@ public class MusicBrainzTransforms {
     final String valueKeyName = "_" + valueKey;
     PCollection<KV<Long, String>> entries = text.apply(MapElements.via((String input) -> {
       MusicBrainzDataObject object = JSONReader.readObject("", input);
-      logger.info(String.format("keyKeyName = %s", keyKeyName), keyKeyName);
-      logger.info(String.format("valueKeyName = %s", valueKeyName), valueKeyName);
+//      logger.info(String.format("keyKeyName = %s", keyKeyName), keyKeyName);
+//      logger.info(String.format("valueKeyName = %s", valueKeyName), valueKeyName);
       // at some point keyKey changes from id to gender and valueKey changes from name to id
       // switch the local variables to prevent the PCollection load from failing due to the following error
       // java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.String
-          if(keyKey.equals("id")) {
+//          if(keyKey.equals("id")) {
             return KV.of((Long) object.getColumnValue(keyKeyName), (String) object.getColumnValue(valueKeyName));
-          } else {
-            return KV.of((Long) object.getColumnValue(valueKeyName), (String) object.getColumnValue(keyKeyName));
-          }
+//          } else {
+//            return KV.of((Long) object.getColumnValue(valueKeyName), (String) object.getColumnValue(keyKeyName));
+//          }
     }).withOutputType(new TypeDescriptor<KV<Long, String>>() {
     }));
 

--- a/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
+++ b/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
@@ -414,6 +414,9 @@ public class MusicBrainzTransforms {
     //[START lookupTableWithSideInputs2]
     Map<String, PCollectionView<Map<Long, String>>> mapSideInputs = new HashMap<String, PCollectionView<Map<Long, String>>>();
     for (LookupDescription mapper : mappers) {
+      logger.info(String.format("loadTableFromText mapper.objectName = %s", mapper.objectName));
+      logger.info(String.format("loadTableFromText mapper.keyKey = %s", mapper.keyKey));
+      logger.info(String.format("loadTableFromText mapper.valueKey = %s", mapper.valueKey));
       PCollectionView<Map<Long, String>> mapView = loadMap(text.getPipeline(), mapper.objectName, mapper.keyKey, mapper.valueKey);
       mapper.destinationKeys.forEach((destinationKey) -> {
         mapSideInputs.put(name + "_" + destinationKey, mapView);
@@ -465,6 +468,9 @@ public class MusicBrainzTransforms {
    * @param valueKey - the name of hte json key to use as the value in the resulting map.
    */
   private static PCollectionView<Map<Long, String>> loadMap(Pipeline p, String name, String keyKey, String valueKey) {
+    logger.info(String.format("loadMap name = %s", name));
+    logger.info(String.format("loadMap keyKey = %s", keyKey));
+    logger.info(String.format("loadMap valueKey = %s", valueKey));
     PCollection<String> text = loadText(p, name);
     return loadMapFromText(text, keyKey, valueKey);
   }

--- a/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
+++ b/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
@@ -16,6 +16,16 @@
 
 package com.google.cloud.bqetl.mbdata;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
@@ -24,15 +34,19 @@ import com.google.cloud.bqetl.mbschema.FieldSchemaListBuilder;
 import com.google.cloud.bqetl.options.BQETLOptions;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.io.TextIO;
-import com.google.cloud.dataflow.sdk.transforms.*;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.Flatten;
+import com.google.cloud.dataflow.sdk.transforms.MapElements;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.View;
 import com.google.cloud.dataflow.sdk.transforms.join.CoGbkResult;
 import com.google.cloud.dataflow.sdk.transforms.join.CoGroupByKey;
 import com.google.cloud.dataflow.sdk.transforms.join.KeyedPCollectionTuple;
-import com.google.cloud.dataflow.sdk.values.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollectionView;
+import com.google.cloud.dataflow.sdk.values.TupleTag;
+import com.google.cloud.dataflow.sdk.values.TypeDescriptor;
 
 
 public class MusicBrainzTransforms {
@@ -405,7 +419,7 @@ public class MusicBrainzTransforms {
     return loadTableFromText(text, name, keyName, mapSideInputs);
   }
 
-  private static PCollection<KV<Long, MusicBrainzDataObject>> loadTableFromText(PCollection<String> text, String name,
+  public static PCollection<KV<Long, MusicBrainzDataObject>> loadTableFromText(PCollection<String> text, String name,
                                                                                String keyName,
                                                                                Map<String, PCollectionView<Map<Long, String>>> mappings) {
     final String namespacedKeyname = name + "_" + keyName;

--- a/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
+++ b/src/main/java/com/google/cloud/bqetl/mbdata/MusicBrainzTransforms.java
@@ -383,8 +383,12 @@ public class MusicBrainzTransforms {
 
     PCollection<KV<Long, String>> entries = text.apply(MapElements.via((String input) -> {
       MusicBrainzDataObject object = JSONReader.readObject("", input);
-      Long key = (Long) object.getColumnValue(keyKeyName);
-      String value = (String) object.getColumnValue(valueKeyName);
+      logger.info("keyKeyName = ", keyKeyName);
+      logger.info("valueKeyName = ", valueKeyName);
+      logger.info("(Long) object.getColumnValue(keyKeyName) = ", (Long) object.getColumnValue(keyKeyName));
+      logger.info("(String) object.getColumnValue(valueKeyName) = ", (String) object.getColumnValue(valueKeyName));
+//      Long key = (Long) object.getColumnValue(keyKeyName);
+//      String value = (String) object.getColumnValue(valueKeyName);
       return KV.of((Long) object.getColumnValue(keyKeyName), (String) object.getColumnValue(valueKeyName));
     }).withOutputType(new TypeDescriptor<KV<Long, String>>() {
     }));

--- a/src/test/java/com/google/cloud/bqetl/MusicBrainzTransformsTest.java
+++ b/src/test/java/com/google/cloud/bqetl/MusicBrainzTransformsTest.java
@@ -16,8 +16,16 @@
 
 package com.google.cloud.bqetl;
 
-import com.google.cloud.bqetl.mbdata.MusicBrainzTransforms;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.google.cloud.bqetl.mbdata.MusicBrainzDataObject;
+import com.google.cloud.bqetl.mbdata.MusicBrainzTransforms;
 import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.runners.DirectPipeline;
 import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
@@ -30,15 +38,7 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import com.google.cloud.dataflow.sdk.values.TypeDescriptor;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.*;
 
 /**
  * Created by johnlabarge on 9/30/16.
@@ -110,8 +110,11 @@ public class MusicBrainzTransformsTest {
 
     DirectPipeline p = DirectPipeline.createForTest();
 
+    // Artist - An artist is generally a musician, a group of musicians, or another music professional (composer, engineer, illustrator, producer, etc.)
     PCollection<String> artistText = p.apply("artist", Create.of(artistLinesOfJson)).setCoder(StringUtf8Coder.of());
     Map<String, PCollectionView<Map<Long, String>>> maps = new HashMap<>();
+    // Area - A country, region, city or the like.
+    // Areas that can be used for filling in the Release country field of releases are listed, by ID, in the country_area table.
     PCollection<String> areaMapText = p.apply("area", Create.of(areaLinesOfJson)).setCoder(StringUtf8Coder.of());
     PCollectionView<Map<Long, String>> areamap = MusicBrainzTransforms.loadMapFromText(areaMapText, "id", "area");
     maps.put("area", areamap);


### PR DESCRIPTION
fixing master branch build failure by making loadTableFromText  public

fixing nested BigQuery job failure with:
* area lookup - removed begin_area from list of destinationKeys to replace
* gender lookup - moved second gender to the end as a destinationKey to replace
* changing innerJoin result name from nested recordings to recordings

reducing simple and nested example disk size from 1,000 GB to 100 GB